### PR TITLE
Update "social networks" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <div class="main">
     <img class="logo" src="assets/img/sherlock-project.svg" alt="Sherlock Project">
     <p class="description">
-      Sherlock, a powerful command line tool provided by Sherlock Project, can be used to find usernames across many <a href="https://github.com/sherlock-project/sherlock/blob/master/sites.md" target="_blank">social networks</a>.
+      Sherlock, a powerful command line tool provided by Sherlock Project, can be used to find usernames across many <a href="https://github.com/sherlock-project/sherlock/blob/master/docs/sites.md" target="_blank">social networks</a>.
       It requires Python 3.6 or higher and works on MacOS, Linux and Windows.
     </p>
     <a class="button installation" href="https://github.com/sherlock-project/sherlock#installation" target="_blank">Installation</a><br>


### PR DESCRIPTION
It previously linked to the now-404'ing https://github.com/sherlock-project/sherlock/blob/master/sites.md.
The current location of `sites.md` is in `docs`, so the link goes to https://github.com/sherlock-project/sherlock/blob/master/docs/sites.md, instead.