### PR TITLE
Update module name to sherlock_project to run without install

### DIFF
--- a/installation.mdx
+++ b/installation.mdx
@@ -153,7 +153,7 @@ docker run --rm -t sherlock user123
     If you'd rather not install directly to your system, you can import the module at runtime with -m.
 
     ```bash
-    python3 -m sherlock user123 user789
+    python3 -m sherlock_project user123 user789
     ```
 
   </Tab>


### PR DESCRIPTION
The suggested command to run Sherlock from source directly without installing returns an error, using the new `sherlock_project` module name works fine.

```
# python3 -m sherlock user123 user789                                                                                                                                                                                                                                   ─╯
/home/davide/github/sherlock/venv/bin/python3: No module named sherlock.__main__; 'sherlock' is a package and cannot be directly executed
```

versus 
```
# python3 -m sherlock_project user123 user789                                                                                                                                                                                                                          ─╯
[*] Checking username user123 on:
..etc
```